### PR TITLE
fix edge file cache segmentfault

### DIFF
--- a/plato/graph/structure/bcsr.hpp
+++ b/plato/graph/structure/bcsr.hpp
@@ -412,13 +412,17 @@ int bcsr_t<EDATA, PART_IMPL, ALLOC>::load_from_cache(const graph_info_t& graph_i
         if (is_outgoing) {
           send(partitioner_->get_partition_id(edge->src_, edge->dst_), *edge);
         } else {
-          auto tmp = edge->src_; edge->src_ = edge->dst_; edge->dst_ = tmp;
-          send(partitioner_->get_partition_id(edge->src_, edge->dst_), *edge);
+          auto reversed_edge = *edge;
+          reversed_edge.src_ = edge->dst_;
+          reversed_edge.dst_ = edge->src_;
+          send(partitioner_->get_partition_id(edge->dst_, edge->src_), reversed_edge);
         }
       } else {
         send(partitioner_->get_partition_id(edge->src_, edge->dst_), *edge);
-        auto tmp = edge->src_; edge->src_ = edge->dst_; edge->dst_ = tmp;
-        send(partitioner_->get_partition_id(edge->src_, edge->dst_), *edge);
+        auto reversed_edge = *edge;
+        reversed_edge.src_ = edge->dst_;
+        reversed_edge.dst_ = edge->src_;
+        send(partitioner_->get_partition_id(edge->dst_, edge->src_), reversed_edge);
       }
       return true;
     };

--- a/plato/graph/structure/cbcsr.hpp
+++ b/plato/graph/structure/cbcsr.hpp
@@ -660,8 +660,10 @@ int cbcsr_t<EDATA, PART_IMPL, ALLOC>::load_from_cache(const graph_info_t& graph_
     auto traversal = [&](size_t, edge_unit_spec_t* edge) {
       send(partitioner_->get_partition_id(edge->src_, edge->dst_), *edge);
       if (false == graph_info.is_directed_) {
-        auto tmp = edge->src_; edge->src_ = edge->dst_; edge->dst_ = tmp;
-        send(partitioner_->get_partition_id(edge->src_, edge->dst_), *edge);
+        auto reversed_edge = *edge;
+        reversed_edge.src_ = edge->dst_;
+        reversed_edge.dst_ = edge->src_;
+        send(partitioner_->get_partition_id(edge->dst_, edge->src_), reversed_edge);
       }
       return true;
     };

--- a/plato/graph/structure/dcsc.hpp
+++ b/plato/graph/structure/dcsc.hpp
@@ -377,8 +377,10 @@ int dcsc_t<EDATA, PART_IMPL, ALLOC>::load_from_cache(const graph_info_t& graph_i
     auto traversal = [&](size_t, edge_unit_spec_t* edge) {
       send(partitioner_->get_partition_id(edge->src_, edge->dst_), *edge);
       if (false == graph_info.is_directed_) {  // cache friendly
-        vid_t tmp = edge->src_; edge->src_ = edge->dst_; edge->dst_ = tmp;
-        send(partitioner_->get_partition_id(edge->src_, edge->dst_), *edge);
+        auto reversed_edge = *edge;
+        reversed_edge.src_ = edge->dst_;
+        reversed_edge.dst_ = edge->src_;
+        send(partitioner_->get_partition_id(edge->dst_, edge->src_), reversed_edge);
       }
       return true;
     };

--- a/plato/graph/structure/hnbbcsr.hpp
+++ b/plato/graph/structure/hnbbcsr.hpp
@@ -699,8 +699,10 @@ int hnbbcsr_t<EDATA, PART_IMPL, ALLOC>::load_from_cache(const graph_info_t& grap
     auto traversal = [&](size_t, edge_unit_spec_t* edge) {
       send(partitioner_->get_partition_id(edge->src_, edge->dst_), *edge);
       if (false == graph_info.is_directed_) {
-        auto tmp = edge->src_; edge->src_ = edge->dst_; edge->dst_ = tmp;
-        send(partitioner_->get_partition_id(edge->src_, edge->dst_), *edge);
+        auto reversed_edge = *edge;
+        reversed_edge.src_ = edge->dst_;
+        reversed_edge.dst_ = edge->src_;
+        send(partitioner_->get_partition_id(edge->dst_, edge->src_), reversed_edge);
       }
       return true;
     };


### PR DESCRIPTION
when load from edge_file_cache，memory will be mapped with `PROT_READ`.