### PR TITLE
fix compile error on centos 7

### DIFF
--- a/3rdtools.sh
+++ b/3rdtools.sh
@@ -88,7 +88,7 @@ function install {
   
   pushd glog-0.4.0
   clean_exec ./autogen.sh
-  clean_exec CXXFLAGS='-fPIC' CFLAGS='-fPIC' LDFLAGS="-L${rootdir}/3rd/libunwind/lib" CPPFLAGS="-I${rootdir}/3rd/libunwind/include" ./configure --enable-shared=no --enable-static=yes --prefix=${rootdir}/3rd/glog-0.4.0
+  clean_exec CXXFLAGS='-fPIC' CFLAGS='-fPIC' LDFLAGS="-L${rootdir}/3rd/libunwind/lib" CPPFLAGS="-I${rootdir}/3rd/libunwind/include" ./configure --enable-shared=no --enable-static=yes --with-gflags=${rootdir}/3rd/gflags-2.2.1 --prefix=${rootdir}/3rd/glog-0.4.0
   clean_exec GFLAGS_LIBS='' make
   clean_exec make install
   popd

--- a/build_tools/BUILD_glog
+++ b/build_tools/BUILD_glog
@@ -11,6 +11,7 @@ cc_library (
     ],
     deps = [
         "//3rd/libunwind:libunwind",
+        "//3rd/gflags:gflags",
     ],
     linkstatic = 1,
     visibility = ["//visibility:public"],


### PR DESCRIPTION
fix compile error on centos 7 with system gflags installed.

CentOS 7 System gflags version: `gflags-devel-2.1.1`.
3rd party gflags version: `2.2.1`.

If the system does not have `gflags-devel` installed, `configure` of `glog` will not use `gflags` as it is an optional requirement; However, if the system has `gflags-devel` installed, system gflags is used. Since `glog` requires higher version of `gflags`, it will cause compile errors as reported in https://github.com/google/glog/issues/389.

To fix this problem, system `gflags` should be overrided by using 3rd party gflags. By doing so, compilation and installation of `glog` can be successfully made on CentOS 7 with system `gflags-devel` installed. 