### PR TITLE
sequence: fix bug when first partition vertices < 4096

### DIFF
--- a/plato/graph/partition/sequence.hpp
+++ b/plato/graph/partition/sequence.hpp
@@ -60,7 +60,7 @@ void __init_offset(std::vector<vid_t>* poffset, const DT* degrees, vid_t vertice
     for (vid_t v_i = poffset->at(p_i); v_i < vertices; ++v_i) {
       amount += (alpha + degrees[v_i]);
       if (amount >= expected_amount) {
-        poffset->at(p_i + 1) = v_i / PAGESIZE * PAGESIZE;
+        poffset->at(p_i + 1) = v_i;
         break;
       }
     }


### PR DESCRIPTION
1. When first partition's vertices size less than 4096, this alignment will cause poffset(1) = 0, and the next loop will start from v_i = 0 again. Finally, the partition offsets are [0, 0), [0, 0), [0, 0) ...
2. this alignment modifies offset, but not adjust amount
3. Why need this alignment ?