### PR TITLE
Support scripts in Amazon Linux 2

### DIFF
--- a/docker/install-dependencies.sh
+++ b/docker/install-dependencies.sh
@@ -55,7 +55,7 @@ function install_bazel() {
 
 if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then
     apt-get install -y "${debian_packages[@]}"
-elif [ "$ID" = "centos" ] || [ "$ID" = "fedora" ] || [ "$ID" = "tlinux" ]; then
+elif [ "$ID" = "centos" ] || [ "$ID" = "fedora" ] || [ "$ID" = "tlinux" ] || [ "$ID" = "amzn" ]; then
     if [ "$ID" = "centos" ] && [ "$VERSION_ID" = "8" ]; then # centos 8
         dnf --enablerepo=PowerTools install -y "${redhat_packages[@]}"
     else


### PR DESCRIPTION
I tried to run `./docker/install-dependencies.sh` on Amazon Linux 2 and it doesn't work.  AL2 is based on Red Hat Enterprise Linux (RHEL). This PR can support the AL2 id.

```
[ec2-user@ip-172-31-53-160 plato]$ cat /etc/os-release
NAME="Amazon Linux"
VERSION="2"
ID="amzn"
ID_LIKE="centos rhel fedora"
VERSION_ID="2"
PRETTY_NAME="Amazon Linux 2"
ANSI_COLOR="0;33"
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
HOME_URL="https://amazonlinux.com/"
```